### PR TITLE
feat: add multi-provider LLM support (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate-types": "motia generate-types"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.21.0",
     "express": "^4.18.0",
     "motia": "0.17.14-beta.196",
     "openai": "^4.50.0",

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -1,0 +1,150 @@
+
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  BaseLLMProvider,
+  GenerationContext,
+  CodeResult,
+  IntentResult,
+  MathEnrichment,
+  ProviderCapability,
+  ProviderConfig,
+} from './base-provider';
+
+const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
+
+export class AnthropicProvider extends BaseLLMProvider {
+  name = 'anthropic';
+  displayName = 'Claude';
+  supportedCapabilities: ProviderCapability[] = [
+    'code_generation',
+    'intent_analysis',
+    'math_enrichment',
+    'vision',
+    'streaming',
+  ];
+
+  private client: Anthropic | null = null;
+
+  constructor(config: ProviderConfig = {}) {
+    super(config);
+    try {
+      if (config.apiKey || process.env.ANTHROPIC_API_KEY) {
+        this.client = new Anthropic({
+          apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY,
+        });
+      }
+    } catch (error) {
+      console.warn('Anthropic client initialization failed:', error);
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.client !== null && !!process.env.ANTHROPIC_API_KEY;
+  }
+
+  async generateCode(prompt: string, context: GenerationContext): Promise<CodeResult> {
+    if (!this.client) throw new Error('Anthropic client not available');
+
+    const systemPrompt = `You are an expert Manim animation developer. Generate clean, working Manim Community Edition code.
+Style: ${context.style || '3blue1brown'}
+Complexity: ${context.complexity || 'medium'}
+${context.prerequisites ? `Prerequisites: ${context.prerequisites.join(', ')}` : ''}
+
+Return ONLY the Python code, no explanations.`;
+
+    const response = await this.client.messages.create({
+      model: this.config.model || DEFAULT_MODEL,
+      max_tokens: this.config.maxTokens || 2000,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const textContent = response.content.find((c) => c.type === 'text');
+    const code = textContent?.type === 'text' ? textContent.text : '';
+
+    return {
+      code: this.extractPythonCode(code),
+      confidence: 0.9,
+      usedTemplate: false,
+    };
+  }
+
+  async analyzeIntent(text: string): Promise<IntentResult> {
+    if (!this.client) throw new Error('Anthropic client not available');
+
+    const response = await this.client.messages.create({
+      model: this.config.model || DEFAULT_MODEL,
+      max_tokens: 1000,
+      system: `Analyze the user's intent for creating a mathematical animation. Return ONLY valid JSON:
+{
+  "intent": "VISUALIZE_MATH|EXPLAIN_CONCEPT|TRANSFORM_OBJECT|GRAPH_FUNCTION|GEOMETRIC_PROOF|KINETIC_TEXT|CREATE_SCENE",
+  "confidence": 0.0-1.0,
+  "entities": {
+    "objects": ["circle", "square"],
+    "actions": ["rotate", "transform"],
+    "colors": ["blue", "red"],
+    "mathExpressions": ["x^2", "\\\\frac{a}{b}"]
+  },
+  "suggestedSkill": "math-visualizer|animation-composer|visual-storyteller|motion-graphics"
+}`,
+      messages: [{ role: 'user', content: text }],
+    });
+
+    const textContent = response.content.find((c) => c.type === 'text');
+    const content = textContent?.type === 'text' ? textContent.text : '{}';
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      intent: parsed.intent || 'CREATE_SCENE',
+      confidence: parsed.confidence || 0.8,
+      entities: parsed.entities || { objects: [], actions: [], colors: [], mathExpressions: [] },
+      suggestedSkill: parsed.suggestedSkill,
+    };
+  }
+
+  async enrichMath(concept: string): Promise<MathEnrichment> {
+    if (!this.client) throw new Error('Anthropic client not available');
+
+    const response = await this.client.messages.create({
+      model: this.config.model || DEFAULT_MODEL,
+      max_tokens: 1500,
+      system: `You are a mathematics expert. Enrich the given concept with mathematical content. Return ONLY valid JSON:
+{
+  "equations": ["Primary equations in LaTeX"],
+  "theorems": ["Relevant theorem names"],
+  "definitions": ["Key definitions"],
+  "proofSteps": ["Step-by-step proof if applicable"],
+  "latex": ["All LaTeX expressions needed for visualization"]
+}`,
+      messages: [{ role: 'user', content: concept }],
+    });
+
+    const textContent = response.content.find((c) => c.type === 'text');
+    const content = textContent?.type === 'text' ? textContent.text : '{}';
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      equations: parsed.equations || [],
+      theorems: parsed.theorems || [],
+      definitions: parsed.definitions || [],
+      proofSteps: parsed.proofSteps,
+      latex: parsed.latex || [],
+    };
+  }
+
+  private extractPythonCode(text: string): string {
+    const codeMatch = text.match(/```python\n([\s\S]*?)```/);
+    if (codeMatch) return codeMatch[1].trim();
+
+    const pyMatch = text.match(/```\n([\s\S]*?)```/);
+    if (pyMatch) return pyMatch[1].trim();
+
+    return text.trim();
+  }
+}
+
+export const anthropicProvider = new AnthropicProvider();

--- a/src/providers/anthropic-provider.ts
+++ b/src/providers/anthropic-provider.ts
@@ -10,7 +10,7 @@ import {
   ProviderConfig,
 } from './base-provider';
 
-const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
+const DEFAULT_MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5-20250929';
 
 export class AnthropicProvider extends BaseLLMProvider {
   name = 'anthropic';

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -1,0 +1,107 @@
+
+export interface GenerationContext {
+  concept: string;
+  intent?: string;
+  style?: string;
+  complexity?: 'simple' | 'medium' | 'complex';
+  existingCode?: string;
+  prerequisites?: string[];
+  visualDesign?: {
+    colorPalette?: string[];
+    cameraMovements?: string[];
+  };
+}
+
+export interface CodeResult {
+  code: string;
+  confidence: number;
+  usedTemplate: boolean;
+  templateName?: string;
+  explanation?: string;
+  suggestedAnimations?: string[];
+}
+
+export interface IntentResult {
+  intent: string;
+  confidence: number;
+  entities: {
+    objects: string[];
+    actions: string[];
+    colors: string[];
+    mathExpressions: string[];
+  };
+  suggestedSkill?: string;
+}
+
+export interface MathEnrichment {
+  equations: string[];
+  theorems: string[];
+  definitions: string[];
+  proofSteps?: string[];
+  latex: string[];
+}
+
+export type ProviderCapability =
+  | 'code_generation'
+  | 'intent_analysis'
+  | 'math_enrichment'
+  | 'vision'
+  | 'streaming'
+  | 'function_calling';
+
+export interface LLMProvider {
+  name: string;
+  displayName: string;
+  supportedCapabilities: ProviderCapability[];
+
+  isAvailable(): boolean;
+
+  generateCode(prompt: string, context: GenerationContext): Promise<CodeResult>;
+
+  analyzeIntent(text: string): Promise<IntentResult>;
+
+  enrichMath(concept: string): Promise<MathEnrichment>;
+
+  healthCheck(): Promise<boolean>;
+}
+
+export interface ProviderConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  timeout?: number;
+}
+
+export abstract class BaseLLMProvider implements LLMProvider {
+  abstract name: string;
+  abstract displayName: string;
+  abstract supportedCapabilities: ProviderCapability[];
+
+  protected config: ProviderConfig;
+
+  constructor(config: ProviderConfig = {}) {
+    this.config = {
+      temperature: 0.7,
+      maxTokens: 2000,
+      timeout: 30000,
+      ...config,
+    };
+  }
+
+  abstract isAvailable(): boolean;
+  abstract generateCode(prompt: string, context: GenerationContext): Promise<CodeResult>;
+  abstract analyzeIntent(text: string): Promise<IntentResult>;
+  abstract enrichMath(concept: string): Promise<MathEnrichment>;
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      if (!this.isAvailable()) return false;
+      const result = await this.analyzeIntent('test');
+      return result.intent !== undefined;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/providers/deepseek-provider.ts
+++ b/src/providers/deepseek-provider.ts
@@ -1,0 +1,158 @@
+
+import OpenAI from 'openai';
+import {
+  BaseLLMProvider,
+  GenerationContext,
+  CodeResult,
+  IntentResult,
+  MathEnrichment,
+  ProviderCapability,
+  ProviderConfig,
+} from './base-provider';
+
+const DEFAULT_MODEL = process.env.DEEPSEEK_MODEL || 'deepseek-reasoner';
+const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1';
+
+export class DeepSeekProvider extends BaseLLMProvider {
+  name = 'deepseek';
+  displayName = 'DeepSeek R1';
+  supportedCapabilities: ProviderCapability[] = [
+    'code_generation',
+    'intent_analysis',
+    'math_enrichment',
+  ];
+
+  private client: OpenAI | null = null;
+
+  constructor(config: ProviderConfig = {}) {
+    super(config);
+    try {
+      const apiKey = config.apiKey || process.env.DEEPSEEK_API_KEY;
+      if (apiKey) {
+        this.client = new OpenAI({
+          apiKey,
+          baseURL: config.baseUrl || DEFAULT_BASE_URL,
+        });
+      }
+    } catch (error) {
+      console.warn('DeepSeek client initialization failed:', error);
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.client !== null && !!process.env.DEEPSEEK_API_KEY;
+  }
+
+  async generateCode(prompt: string, context: GenerationContext): Promise<CodeResult> {
+    if (!this.client) throw new Error('DeepSeek client not available');
+
+    const systemPrompt = `You are an expert Manim animation developer. Generate clean, working Manim Community Edition code.
+Style: ${context.style || '3blue1brown'}
+Complexity: ${context.complexity || 'medium'}
+
+Return ONLY the Python code, no explanations.`;
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      temperature: this.config.temperature,
+      max_tokens: this.config.maxTokens,
+    });
+
+    const code = response.choices[0]?.message?.content || '';
+
+    return {
+      code: this.extractPythonCode(code),
+      confidence: 0.85,
+      usedTemplate: false,
+    };
+  }
+
+  async analyzeIntent(text: string): Promise<IntentResult> {
+    if (!this.client) throw new Error('DeepSeek client not available');
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        {
+          role: 'system',
+          content: `Analyze the user's intent for creating a mathematical animation. Return JSON:
+{
+  "intent": "VISUALIZE_MATH|EXPLAIN_CONCEPT|TRANSFORM_OBJECT|GRAPH_FUNCTION|GEOMETRIC_PROOF|KINETIC_TEXT|CREATE_SCENE",
+  "confidence": 0.0-1.0,
+  "entities": {
+    "objects": [],
+    "actions": [],
+    "colors": [],
+    "mathExpressions": []
+  },
+  "suggestedSkill": "math-visualizer|animation-composer|visual-storyteller|motion-graphics"
+}`,
+        },
+        { role: 'user', content: text },
+      ],
+      temperature: 0.3,
+    });
+
+    const content = response.choices[0]?.message?.content || '{}';
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      intent: parsed.intent || 'CREATE_SCENE',
+      confidence: parsed.confidence || 0.75,
+      entities: parsed.entities || { objects: [], actions: [], colors: [], mathExpressions: [] },
+      suggestedSkill: parsed.suggestedSkill,
+    };
+  }
+
+  async enrichMath(concept: string): Promise<MathEnrichment> {
+    if (!this.client) throw new Error('DeepSeek client not available');
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        {
+          role: 'system',
+          content: `You are a mathematics expert. Enrich the given concept with mathematical content. Return JSON:
+{
+  "equations": ["Primary equations in LaTeX"],
+  "theorems": ["Relevant theorem names"],
+  "definitions": ["Key definitions"],
+  "proofSteps": ["Step-by-step proof if applicable"],
+  "latex": ["All LaTeX expressions needed for visualization"]
+}`,
+        },
+        { role: 'user', content: concept },
+      ],
+      temperature: 0.3,
+    });
+
+    const content = response.choices[0]?.message?.content || '{}';
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      equations: parsed.equations || [],
+      theorems: parsed.theorems || [],
+      definitions: parsed.definitions || [],
+      proofSteps: parsed.proofSteps,
+      latex: parsed.latex || [],
+    };
+  }
+
+  private extractPythonCode(text: string): string {
+    const codeMatch = text.match(/```python\n([\s\S]*?)```/);
+    if (codeMatch) return codeMatch[1].trim();
+
+    const pyMatch = text.match(/```\n([\s\S]*?)```/);
+    if (pyMatch) return pyMatch[1].trim();
+
+    return text.trim();
+  }
+}
+
+export const deepseekProvider = new DeepSeekProvider();

--- a/src/providers/fallback-chain.ts
+++ b/src/providers/fallback-chain.ts
@@ -9,8 +9,21 @@ interface FallbackConfig {
   onFallback?: (from: ProviderName, to: ProviderName, error: Error) => void;
 }
 
+const validProviders: ProviderName[] = ['openai', 'anthropic', 'google', 'deepseek'];
+
+function getDefaultChain(): ProviderName[] {
+  const envChain = process.env.FALLBACK_CHAIN;
+  if (envChain) {
+    const chain = envChain.split(',').filter(p => validProviders.includes(p as ProviderName)) as ProviderName[];
+    if (chain.length > 0) {
+      return chain;
+    }
+  }
+  return ['anthropic', 'openai', 'google', 'deepseek'];
+}
+
 const DEFAULT_FALLBACK_CONFIG: FallbackConfig = {
-  chain: (process.env.FALLBACK_CHAIN?.split(',') as ProviderName[]) || ['anthropic', 'openai', 'google', 'deepseek'],
+  chain: getDefaultChain(),
   maxRetries: 3,
   retryDelayMs: 1000,
 };

--- a/src/providers/fallback-chain.ts
+++ b/src/providers/fallback-chain.ts
@@ -1,0 +1,144 @@
+
+import type { LLMProvider, GenerationContext, CodeResult, IntentResult, MathEnrichment } from './base-provider';
+import { providerRouter, ProviderName } from './provider-router';
+
+interface FallbackConfig {
+  chain: ProviderName[];
+  maxRetries: number;
+  retryDelayMs: number;
+  onFallback?: (from: ProviderName, to: ProviderName, error: Error) => void;
+}
+
+const DEFAULT_FALLBACK_CONFIG: FallbackConfig = {
+  chain: (process.env.FALLBACK_CHAIN?.split(',') as ProviderName[]) || ['anthropic', 'openai', 'google', 'deepseek'],
+  maxRetries: 3,
+  retryDelayMs: 1000,
+};
+
+export class FallbackChain {
+  private config: FallbackConfig;
+  private failureCount: Map<ProviderName, number> = new Map();
+
+  constructor(config: Partial<FallbackConfig> = {}) {
+    this.config = { ...DEFAULT_FALLBACK_CONFIG, ...config };
+  }
+
+  async generateCode(prompt: string, context: GenerationContext): Promise<CodeResult & { provider: string }> {
+    return this.executeWithFallback(
+      async (provider) => {
+        const result = await provider.generateCode(prompt, context);
+        return { ...result, provider: provider.name };
+      },
+      'code_generation'
+    );
+  }
+
+  async analyzeIntent(text: string): Promise<IntentResult & { provider: string }> {
+    return this.executeWithFallback(
+      async (provider) => {
+        const result = await provider.analyzeIntent(text);
+        return { ...result, provider: provider.name };
+      },
+      'intent_analysis'
+    );
+  }
+
+  async enrichMath(concept: string): Promise<MathEnrichment & { provider: string }> {
+    return this.executeWithFallback(
+      async (provider) => {
+        const result = await provider.enrichMath(concept);
+        return { ...result, provider: provider.name };
+      },
+      'math_enrichment'
+    );
+  }
+
+  private async executeWithFallback<T>(
+    fn: (provider: LLMProvider) => Promise<T>,
+    taskType: string
+  ): Promise<T> {
+    const errors: Error[] = [];
+
+    for (const providerName of this.config.chain) {
+      const provider = providerRouter.getProviderByName(providerName);
+      if (!provider) continue;
+
+      const failures = this.failureCount.get(providerName) || 0;
+      if (failures >= this.config.maxRetries) {
+        continue;
+      }
+
+      try {
+        const result = await fn(provider);
+        this.failureCount.set(providerName, 0);
+        return result;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        errors.push(err);
+
+        this.failureCount.set(providerName, failures + 1);
+
+        const nextProvider = this.getNextAvailableProvider(providerName);
+        if (nextProvider && this.config.onFallback) {
+          this.config.onFallback(providerName, nextProvider, err);
+        }
+
+        if (this.config.retryDelayMs > 0) {
+          await this.delay(this.config.retryDelayMs);
+        }
+      }
+    }
+
+    throw new Error(
+      `All providers failed for ${taskType}. Errors: ${errors.map((e) => e.message).join('; ')}`
+    );
+  }
+
+  private getNextAvailableProvider(current: ProviderName): ProviderName | null {
+    const currentIndex = this.config.chain.indexOf(current);
+    for (let i = currentIndex + 1; i < this.config.chain.length; i++) {
+      const provider = providerRouter.getProviderByName(this.config.chain[i]);
+      if (provider) {
+        return this.config.chain[i];
+      }
+    }
+    return null;
+  }
+
+  resetFailureCounts(): void {
+    this.failureCount.clear();
+  }
+
+  getFailureCounts(): Record<ProviderName, number> {
+    const result: Record<string, number> = {};
+    for (const [name, count] of this.failureCount.entries()) {
+      result[name] = count;
+    }
+    return result as Record<ProviderName, number>;
+  }
+
+  updateConfig(config: Partial<FallbackConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+export const fallbackChain = new FallbackChain();
+
+export async function generateCodeWithFallback(
+  prompt: string,
+  context: GenerationContext
+): Promise<CodeResult & { provider: string }> {
+  return fallbackChain.generateCode(prompt, context);
+}
+
+export async function analyzeIntentWithFallback(text: string): Promise<IntentResult & { provider: string }> {
+  return fallbackChain.analyzeIntent(text);
+}
+
+export async function enrichMathWithFallback(concept: string): Promise<MathEnrichment & { provider: string }> {
+  return fallbackChain.enrichMath(concept);
+}

--- a/src/providers/google-provider.ts
+++ b/src/providers/google-provider.ts
@@ -1,0 +1,147 @@
+
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import {
+  BaseLLMProvider,
+  GenerationContext,
+  CodeResult,
+  IntentResult,
+  MathEnrichment,
+  ProviderCapability,
+  ProviderConfig,
+} from './base-provider';
+
+const DEFAULT_MODEL = process.env.GOOGLE_MODEL || 'gemini-2.0-flash';
+
+export class GoogleProvider extends BaseLLMProvider {
+  name = 'google';
+  displayName = 'Gemini';
+  supportedCapabilities: ProviderCapability[] = [
+    'code_generation',
+    'intent_analysis',
+    'math_enrichment',
+    'vision',
+    'streaming',
+  ];
+
+  private client: GoogleGenerativeAI | null = null;
+
+  constructor(config: ProviderConfig = {}) {
+    super(config);
+    try {
+      const apiKey = config.apiKey || process.env.GOOGLE_API_KEY;
+      if (apiKey) {
+        this.client = new GoogleGenerativeAI(apiKey);
+      }
+    } catch (error) {
+      console.warn('Google AI client initialization failed:', error);
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.client !== null && !!process.env.GOOGLE_API_KEY;
+  }
+
+  async generateCode(prompt: string, context: GenerationContext): Promise<CodeResult> {
+    if (!this.client) throw new Error('Google AI client not available');
+
+    const model = this.client.getGenerativeModel({ model: this.config.model || DEFAULT_MODEL });
+
+    const systemPrompt = `You are an expert Manim animation developer. Generate clean, working Manim Community Edition code.
+Style: ${context.style || '3blue1brown'}
+Complexity: ${context.complexity || 'medium'}
+${context.prerequisites ? `Prerequisites: ${context.prerequisites.join(', ')}` : ''}
+
+Return ONLY the Python code, no explanations.
+
+User request: ${prompt}`;
+
+    const result = await model.generateContent(systemPrompt);
+    const response = await result.response;
+    const code = response.text();
+
+    return {
+      code: this.extractPythonCode(code),
+      confidence: 0.8,
+      usedTemplate: false,
+    };
+  }
+
+  async analyzeIntent(text: string): Promise<IntentResult> {
+    if (!this.client) throw new Error('Google AI client not available');
+
+    const model = this.client.getGenerativeModel({ model: this.config.model || DEFAULT_MODEL });
+
+    const prompt = `Analyze the user's intent for creating a mathematical animation. Return ONLY valid JSON:
+{
+  "intent": "VISUALIZE_MATH|EXPLAIN_CONCEPT|TRANSFORM_OBJECT|GRAPH_FUNCTION|GEOMETRIC_PROOF|KINETIC_TEXT|CREATE_SCENE",
+  "confidence": 0.0-1.0,
+  "entities": {
+    "objects": ["circle", "square"],
+    "actions": ["rotate", "transform"],
+    "colors": ["blue", "red"],
+    "mathExpressions": ["x^2", "\\\\frac{a}{b}"]
+  },
+  "suggestedSkill": "math-visualizer|animation-composer|visual-storyteller|motion-graphics"
+}
+
+User input: ${text}`;
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const content = response.text();
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      intent: parsed.intent || 'CREATE_SCENE',
+      confidence: parsed.confidence || 0.75,
+      entities: parsed.entities || { objects: [], actions: [], colors: [], mathExpressions: [] },
+      suggestedSkill: parsed.suggestedSkill,
+    };
+  }
+
+  async enrichMath(concept: string): Promise<MathEnrichment> {
+    if (!this.client) throw new Error('Google AI client not available');
+
+    const model = this.client.getGenerativeModel({ model: this.config.model || DEFAULT_MODEL });
+
+    const prompt = `You are a mathematics expert. Enrich the given concept with mathematical content. Return ONLY valid JSON:
+{
+  "equations": ["Primary equations in LaTeX"],
+  "theorems": ["Relevant theorem names"],
+  "definitions": ["Key definitions"],
+  "proofSteps": ["Step-by-step proof if applicable"],
+  "latex": ["All LaTeX expressions needed for visualization"]
+}
+
+Concept: ${concept}`;
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const content = response.text();
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : {};
+
+    return {
+      equations: parsed.equations || [],
+      theorems: parsed.theorems || [],
+      definitions: parsed.definitions || [],
+      proofSteps: parsed.proofSteps,
+      latex: parsed.latex || [],
+    };
+  }
+
+  private extractPythonCode(text: string): string {
+    const codeMatch = text.match(/```python\n([\s\S]*?)```/);
+    if (codeMatch) return codeMatch[1].trim();
+
+    const pyMatch = text.match(/```\n([\s\S]*?)```/);
+    if (pyMatch) return pyMatch[1].trim();
+
+    return text.trim();
+  }
+}
+
+export const googleProvider = new GoogleProvider();

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,64 @@
+
+export {
+  LLMProvider,
+  BaseLLMProvider,
+  GenerationContext,
+  CodeResult,
+  IntentResult,
+  MathEnrichment,
+  ProviderCapability,
+  ProviderConfig,
+} from './base-provider';
+
+export { OpenAIProvider, openaiProvider } from './openai-provider';
+export { AnthropicProvider, anthropicProvider } from './anthropic-provider';
+export { GoogleProvider, googleProvider } from './google-provider';
+export { DeepSeekProvider, deepseekProvider } from './deepseek-provider';
+
+export {
+  ProviderRouter,
+  providerRouter,
+  getDefaultProvider,
+  isAnyProviderAvailable,
+  TaskType,
+  ProviderName,
+} from './provider-router';
+
+export {
+  FallbackChain,
+  fallbackChain,
+  generateCodeWithFallback,
+  analyzeIntentWithFallback,
+  enrichMathWithFallback,
+} from './fallback-chain';
+
+export function getProviderStatus(): Record<string, boolean> {
+  return {
+    openai: openaiProvider.isAvailable(),
+    anthropic: anthropicProvider.isAvailable(),
+    google: googleProvider.isAvailable(),
+    deepseek: deepseekProvider.isAvailable(),
+  };
+}
+
+export function getProviderSummary(): {
+  available: string[];
+  unavailable: string[];
+  default: string | null;
+} {
+  const status = getProviderStatus();
+  const available = Object.entries(status)
+    .filter(([, v]) => v)
+    .map(([k]) => k);
+  const unavailable = Object.entries(status)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+
+  const defaultProvider = getDefaultProvider();
+
+  return {
+    available,
+    unavailable,
+    default: defaultProvider?.name || null,
+  };
+}

--- a/src/providers/openai-provider.ts
+++ b/src/providers/openai-provider.ts
@@ -1,0 +1,158 @@
+
+import OpenAI from 'openai';
+import {
+  BaseLLMProvider,
+  GenerationContext,
+  CodeResult,
+  IntentResult,
+  MathEnrichment,
+  ProviderCapability,
+  ProviderConfig,
+} from './base-provider';
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o';
+
+export class OpenAIProvider extends BaseLLMProvider {
+  name = 'openai';
+  displayName = 'OpenAI GPT-4';
+  supportedCapabilities: ProviderCapability[] = [
+    'code_generation',
+    'intent_analysis',
+    'math_enrichment',
+    'vision',
+    'streaming',
+    'function_calling',
+  ];
+
+  private client: OpenAI | null = null;
+
+  constructor(config: ProviderConfig = {}) {
+    super(config);
+    try {
+      this.client = new OpenAI({
+        apiKey: config.apiKey || process.env.OPENAI_API_KEY,
+        baseURL: config.baseUrl,
+      });
+    } catch (error) {
+      console.warn('OpenAI client initialization failed:', error);
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.client !== null && !!process.env.OPENAI_API_KEY;
+  }
+
+  async generateCode(prompt: string, context: GenerationContext): Promise<CodeResult> {
+    if (!this.client) throw new Error('OpenAI client not available');
+
+    const systemPrompt = `You are an expert Manim animation developer. Generate clean, working Manim Community Edition code.
+Style: ${context.style || '3blue1brown'}
+Complexity: ${context.complexity || 'medium'}
+${context.prerequisites ? `Prerequisites: ${context.prerequisites.join(', ')}` : ''}
+
+Return ONLY the Python code, no explanations.`;
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      temperature: this.config.temperature,
+      max_tokens: this.config.maxTokens,
+    });
+
+    const code = response.choices[0]?.message?.content || '';
+
+    return {
+      code: this.extractPythonCode(code),
+      confidence: 0.85,
+      usedTemplate: false,
+    };
+  }
+
+  async analyzeIntent(text: string): Promise<IntentResult> {
+    if (!this.client) throw new Error('OpenAI client not available');
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        {
+          role: 'system',
+          content: `Analyze the user's intent for creating a mathematical animation. Return JSON:
+{
+  "intent": "VISUALIZE_MATH|EXPLAIN_CONCEPT|TRANSFORM_OBJECT|GRAPH_FUNCTION|GEOMETRIC_PROOF|KINETIC_TEXT|CREATE_SCENE",
+  "confidence": 0.0-1.0,
+  "entities": {
+    "objects": ["circle", "square"],
+    "actions": ["rotate", "transform"],
+    "colors": ["blue", "red"],
+    "mathExpressions": ["x^2", "\\\\frac{a}{b}"]
+  },
+  "suggestedSkill": "math-visualizer|animation-composer|visual-storyteller|motion-graphics"
+}`,
+        },
+        { role: 'user', content: text },
+      ],
+      temperature: 0.3,
+      response_format: { type: 'json_object' },
+    });
+
+    const content = response.choices[0]?.message?.content || '{}';
+    const parsed = JSON.parse(content);
+
+    return {
+      intent: parsed.intent || 'CREATE_SCENE',
+      confidence: parsed.confidence || 0.7,
+      entities: parsed.entities || { objects: [], actions: [], colors: [], mathExpressions: [] },
+      suggestedSkill: parsed.suggestedSkill,
+    };
+  }
+
+  async enrichMath(concept: string): Promise<MathEnrichment> {
+    if (!this.client) throw new Error('OpenAI client not available');
+
+    const response = await this.client.chat.completions.create({
+      model: this.config.model || DEFAULT_MODEL,
+      messages: [
+        {
+          role: 'system',
+          content: `You are a mathematics expert. Enrich the given concept with mathematical content. Return JSON:
+{
+  "equations": ["Primary equations in LaTeX"],
+  "theorems": ["Relevant theorem names"],
+  "definitions": ["Key definitions"],
+  "proofSteps": ["Step-by-step proof if applicable"],
+  "latex": ["All LaTeX expressions needed for visualization"]
+}`,
+        },
+        { role: 'user', content: concept },
+      ],
+      temperature: 0.3,
+      response_format: { type: 'json_object' },
+    });
+
+    const content = response.choices[0]?.message?.content || '{}';
+    const parsed = JSON.parse(content);
+
+    return {
+      equations: parsed.equations || [],
+      theorems: parsed.theorems || [],
+      definitions: parsed.definitions || [],
+      proofSteps: parsed.proofSteps,
+      latex: parsed.latex || [],
+    };
+  }
+
+  private extractPythonCode(text: string): string {
+    const codeMatch = text.match(/```python\n([\s\S]*?)```/);
+    if (codeMatch) return codeMatch[1].trim();
+
+    const pyMatch = text.match(/```\n([\s\S]*?)```/);
+    if (pyMatch) return pyMatch[1].trim();
+
+    return text.trim();
+  }
+}
+
+export const openaiProvider = new OpenAIProvider();

--- a/src/providers/provider-router.ts
+++ b/src/providers/provider-router.ts
@@ -1,0 +1,147 @@
+
+import type { LLMProvider, GenerationContext, CodeResult, IntentResult, MathEnrichment } from './base-provider';
+import { openaiProvider } from './openai-provider';
+import { anthropicProvider } from './anthropic-provider';
+import { googleProvider } from './google-provider';
+import { deepseekProvider } from './deepseek-provider';
+
+export type TaskType = 'code_generation' | 'intent_analysis' | 'math_enrichment' | 'creative';
+export type ProviderName = 'openai' | 'anthropic' | 'google' | 'deepseek';
+
+interface RoutingConfig {
+  default: ProviderName;
+  taskRouting: Record<TaskType, ProviderName[]>;
+  costOptimize: boolean;
+}
+
+const DEFAULT_ROUTING_CONFIG: RoutingConfig = {
+  default: 'anthropic',
+  taskRouting: {
+    code_generation: ['anthropic', 'openai', 'deepseek'],
+    intent_analysis: ['anthropic', 'openai', 'google'],
+    math_enrichment: ['google', 'deepseek', 'anthropic'],
+    creative: ['anthropic', 'openai'],
+  },
+  costOptimize: process.env.COST_OPTIMIZE === 'true',
+};
+
+const PROVIDERS: Record<ProviderName, LLMProvider> = {
+  openai: openaiProvider,
+  anthropic: anthropicProvider,
+  google: googleProvider,
+  deepseek: deepseekProvider,
+};
+
+export class ProviderRouter {
+  private config: RoutingConfig;
+  private healthStatus: Map<ProviderName, boolean> = new Map();
+
+  constructor(config: Partial<RoutingConfig> = {}) {
+    this.config = { ...DEFAULT_ROUTING_CONFIG, ...config };
+    this.initHealthCheck();
+  }
+
+  private async initHealthCheck(): Promise<void> {
+    for (const [name, provider] of Object.entries(PROVIDERS)) {
+      this.healthStatus.set(name as ProviderName, provider.isAvailable());
+    }
+  }
+
+  getProvider(taskType: TaskType): LLMProvider | null {
+    const preferredProviders = this.config.taskRouting[taskType] || [this.config.default];
+
+    for (const providerName of preferredProviders) {
+      const provider = PROVIDERS[providerName];
+      if (provider?.isAvailable()) {
+        return provider;
+      }
+    }
+
+    for (const [name, provider] of Object.entries(PROVIDERS)) {
+      if (provider.isAvailable()) {
+        return provider;
+      }
+    }
+
+    return null;
+  }
+
+  getProviderByName(name: ProviderName): LLMProvider | null {
+    const provider = PROVIDERS[name];
+    return provider?.isAvailable() ? provider : null;
+  }
+
+  getAvailableProviders(): LLMProvider[] {
+    return Object.values(PROVIDERS).filter((p) => p.isAvailable());
+  }
+
+  async generateCode(prompt: string, context: GenerationContext, preferredProvider?: ProviderName): Promise<CodeResult> {
+    const provider = preferredProvider
+      ? this.getProviderByName(preferredProvider)
+      : this.getProvider('code_generation');
+
+    if (!provider) {
+      throw new Error('No provider available for code generation');
+    }
+
+    return provider.generateCode(prompt, context);
+  }
+
+  async analyzeIntent(text: string, preferredProvider?: ProviderName): Promise<IntentResult> {
+    const provider = preferredProvider
+      ? this.getProviderByName(preferredProvider)
+      : this.getProvider('intent_analysis');
+
+    if (!provider) {
+      throw new Error('No provider available for intent analysis');
+    }
+
+    return provider.analyzeIntent(text);
+  }
+
+  async enrichMath(concept: string, preferredProvider?: ProviderName): Promise<MathEnrichment> {
+    const provider = preferredProvider
+      ? this.getProviderByName(preferredProvider)
+      : this.getProvider('math_enrichment');
+
+    if (!provider) {
+      throw new Error('No provider available for math enrichment');
+    }
+
+    return provider.enrichMath(concept);
+  }
+
+  updateConfig(config: Partial<RoutingConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  getConfig(): RoutingConfig {
+    return { ...this.config };
+  }
+
+  async checkHealth(): Promise<Record<ProviderName, boolean>> {
+    const results: Record<string, boolean> = {};
+
+    for (const [name, provider] of Object.entries(PROVIDERS)) {
+      try {
+        results[name] = await provider.healthCheck();
+        this.healthStatus.set(name as ProviderName, results[name]);
+      } catch {
+        results[name] = false;
+        this.healthStatus.set(name as ProviderName, false);
+      }
+    }
+
+    return results as Record<ProviderName, boolean>;
+  }
+}
+
+export const providerRouter = new ProviderRouter();
+
+export function getDefaultProvider(): LLMProvider | null {
+  return providerRouter.getProvider('code_generation');
+}
+
+export function isAnyProviderAvailable(): boolean {
+  return providerRouter.getAvailableProviders().length > 0;
+}


### PR DESCRIPTION
## Summary
- Adds abstraction layer for multiple LLM providers
- Implements OpenAI, Anthropic, Google Gemini, DeepSeek providers
- Adds intelligent provider routing based on task type
- Includes automatic fallback chain for resilience

## Test plan
- [ ] Test each provider integration
- [ ] Verify fallback chain triggers on errors
- [ ] Validate provider routing logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified provider framework and four concrete LLM providers (OpenAI, Anthropic, Google/Gemini, DeepSeek).
  * Implemented code generation, intent analysis, and math enrichment across providers (plus vision/streaming/function-calling where supported).
  * Added provider routing, health checks, and a fallback chain with retries and failover callbacks.
  * Exposed provider status/summary helpers and simple wrapper APIs for routed/fallbacked operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->