### PR TITLE
Deploy React dashboard to Vercel instead of static HTML

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
   "framework": "vite",
-  "installCommand": "npm install",
+  "buildCommand": "cd dashboard && npm install && npm run build",
+  "outputDirectory": "dashboard/dist",
+  "installCommand": "cd dashboard && npm install",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Moves vercel.json to root and configures it to build the React dashboard (`dashboard/` folder)
- The sketchy design React app will be deployed instead of the purple static HTML

## After merging
Set this environment variable in Vercel dashboard:
- `VITE_API_URL` = `https://eh2524-hjzqoc.ghumare64-rsnb.motia.cloud`

Then redeploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment build configuration to direct builds and installations to the dashboard subdirectory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->